### PR TITLE
feat: Add duration support for inputs and improve documentation

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -25,7 +25,7 @@ const getActions = (instance) => {
 	// Populate timelines and cues safely using sorted order
 	const sortedTimelines = instance.getSortedTimelines()
 	instance.log('info', `Processing ${sortedTimelines.length} timelines from Watchout`)
-	
+
 	for (const timeline of sortedTimelines) {
 		instance.CHOICES_TIMELINES.push({ id: timeline.id, label: timeline.name })
 		// instance.log('debug', `Timeline: ID=${timeline.id}, Name="${timeline.name}"`)
@@ -501,7 +501,7 @@ const getActions = (instance) => {
 				label: 'Input Key',
 				id: 'input_key',
 				default: '',
-				tooltip: 'The name/key of the input variable in the show',
+				tooltip: 'The key of the input variable. You must manually set the Key field in the variable properties in Watchout Producer for this to work.',
 			},
 			{
 				type: 'textinput',
@@ -513,6 +513,16 @@ const getActions = (instance) => {
 				max: 999999,
 				step: 0.01,
 				tooltip: 'The value to send to the input variable',
+			},
+			{
+				type: 'number',
+				label: 'Duration (ms)',
+				id: 'duration',
+				default: 0,
+				min: 0,
+				max: 60000,
+				step: 100,
+				tooltip: 'Interpolation duration in milliseconds. 0 = instant change.',
 			},
 		],
 		/**
@@ -528,7 +538,18 @@ const getActions = (instance) => {
 				return
 			}
 
-			const payload = [{ key: inputKey.trim(), value: parseFloat(inputValue) || 0 }]
+			let value = parseFloat(inputValue)
+			if (isNaN(value)) {
+				value = inputValue
+			}
+
+			const inputObj = { key: inputKey.trim(), value: value }
+			const duration = parseInt(action.options.duration) || 0
+			if (duration > 0) {
+				inputObj.duration = duration
+			}
+
+			const payload = [inputObj]
 
 			instance.log('debug', `API send inputs: ${JSON.stringify(payload)}`)
 			try {
@@ -558,8 +579,8 @@ const getActions = (instance) => {
 				useVariables: true,
 				label: 'JSON Input Data',
 				id: 'inputs_json',
-				default: '[{"key": "InputName", "value": 0.5}]',
-				tooltip: 'JSON array of input objects with key and value properties',
+				default: '[{"key": "InputName", "value": 0.5, "duration": 1000}]',
+				tooltip: 'JSON array of input objects with key, value, and optional duration (ms) properties. You must manually set the Key field in the variable properties in Watchout Producer for this to work.',
 			},
 		],
 		/**

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -6,72 +6,83 @@ Because Watchout 7 works with ID's, it is possible to use the same buttons in di
 
 ## Configuration
 
-* **IP address**: The IP address of the Watchout Director
-* **Port**: The HTTP API port (default: 3019)
-* **Sort timelines on name**: When enabled, timeline dropdowns are sorted alphabetically by name. When disabled (default), they are sorted by ID preserving Watchout's native order.
-* **Default toggle behavior**: Choose the default action for timeline toggle when timeline is stopped. Options are "Play" (default) or "Pause".
+- **IP address**: The IP address of the Watchout Director
+- **Port**: The HTTP API port (default: 3019)
+- **Sort timelines on name**: When enabled, timeline dropdowns are sorted alphabetically by name. When disabled (default), they are sorted by ID preserving Watchout's native order.
+- **Default toggle behavior**: Choose the default action for timeline toggle when timeline is stopped. Options are "Play" (default) or "Pause".
 
 ## Connection Method
 
 The module uses a **dual update system**:
+
 - **Real-time updates (SSE)**: Instant feedback for playback states, input changes, and media presets
 - **Periodic polling (30s)**: Detects timeline structure changes, new cues, and show updates
 
 ## Actions
 
 ### Timeline Control
-* **Timeline Action**: Play, pause, or stop a specific timeline
-* **Timeline Toggle**: Toggle between play and pause for a timeline (smart detection of current state)
-* **Only play timeline if**: Conditional playback - play a timeline only if it's in a specific state
-* **Only play timeline if other timeline condition is met**: Play timeline A when timeline B is in a specific state
+
+- **Timeline Action**: Play, pause, or stop a specific timeline
+- **Timeline Toggle**: Toggle between play and pause for a timeline (smart detection of current state)
+- **Only play timeline if**: Conditional playback - play a timeline only if it's in a specific state
+- **Only play timeline if other timeline condition is met**: Play timeline A when timeline B is in a specific state
 
 ### Timeline Navigation
-* **Jump to Time**: Jump to a specific time (in milliseconds) with play or pause state
-* **Jump to Cue**: Jump to a specific cue with play or pause state
+
+- **Jump to Time**: Jump to a specific time (in milliseconds) with play or pause state
+- **Jump to Cue**: Jump to a specific cue with play or pause state
 
 ### Input Management
-* **Send Input Value**: Send a single value to a show input/variable
-* **Send Multiple Inputs**: Send multiple input values at once using JSON format
-  - Format: `[{"key": "InputName", "value": 0.5}, {"key": "Input2", "value": 1.0}]`
+
+- **Send Input Value**: Send a single value to a show input/variable (supports interpolation duration)
+- **Send Multiple Inputs**: Send multiple input values at once using JSON format (supports interpolation duration per item)
+  - Format: `[{"key": "InputName", "value": 0.5, "duration": 1000}]`
+
+> **Important**: For inputs to work via the HTTP API, you must manually set the **Key** field in the variable properties in Watchout Producer. The API matches on the Key property, not the Name.
 
 ### Show Management
-* **Load Show from JSON**: Load a complete show from JSON data
-* **Load Show from File**: Load a show from a .watch file path on the Watchout system
+
+- **Load Show from JSON**: Load a complete show from JSON data
+- **Load Show from File**: Load a show from a .watch file path on the Watchout system
   - Supports optional show name parameter
-* **Show information**: Manually refresh timeline and show information
+- **Show information**: Manually refresh timeline and show information
 
 ### Cue Set Control
-* **Set group state by with variant**: Set a single cue group to a specific variant
-* **Set Multiple Cue Groups**: Set multiple cue group variants simultaneously using JSON
+
+- **Set group state by with variant**: Set a single cue group to a specific variant
+- **Set Multiple Cue Groups**: Set multiple cue group variants simultaneously using JSON
   - Format: `{"GroupName1": "VariantName1", "GroupName2": "VariantName2"}`
-* **Reset all cue groups by Name**: Reset all cue groups to their default state
+- **Reset all cue groups by Name**: Reset all cue groups to their default state
 
 ### Node Management
-* **Shutdown node**: Shutdown a Watchout node by IP address
-* **Restart Services**: Restart services on a Watchout node by IP address
+
+- **Shutdown node**: Shutdown a Watchout node by IP address
+- **Restart Services**: Restart services on a Watchout node by IP address
 
 ## Variables
 
 The module provides dynamic variables that update automatically:
 
-* **$(companion-module-name:director)**: Name of the Watchout Director
-* **$(companion-module-name:asset_manager)**: Name of the Asset Manager
-* **$(companion-module-name:heartbeat)**: Last reply from Watchout
-* **$(companion-module-name:show_name)**: show_name
-* **$(companion-module-name:TIMELINE_ID)**: Name of each timeline
-* **$(companion-module-name:TIMELINE_ID_CUE_ID)**: When a CUE has a name, it will be shown. If its a timer the value will be the timer value, otherwise it will show the name of the cue
+- **$(companion-module-name:director)**: Name of the Watchout Director
+- **$(companion-module-name:asset_manager)**: Name of the Asset Manager
+- **$(companion-module-name:heartbeat)**: Last reply from Watchout
+- **$(companion-module-name:show_name)**: show_name
+- **$(companion-module-name:TIMELINE_ID)**: Name of each timeline
+- **$(companion-module-name:TIMELINE_ID_CUE_ID)**: When a CUE has a name, it will be shown. If its a timer the value will be the timer value, otherwise it will show the name of the cue
 
 Variables update in real-time via SSE and are refreshed every 30 seconds via polling to catch structural changes.
 
 ## Feedbacks
 
 ### Timeline Status
-* **Timeline Running**: Indicates if a timeline is currently playing
-* **Timeline Paused**: Indicates if a timeline is paused
-* **Timeline Stopped**: Indicates if a timeline is stopped
+
+- **Timeline Running**: Indicates if a timeline is currently playing
+- **Timeline Paused**: Indicates if a timeline is paused
+- **Timeline Stopped**: Indicates if a timeline is stopped
 
 ### Cue Set Status
-* **Cue Set Active**: Indicates if a specific cue group variant is active
+
+- **Cue Set Active**: Indicates if a specific cue group variant is active
 
 All feedbacks update in real-time via the SSE connection for instant visual feedback.
 
@@ -80,75 +91,89 @@ All feedbacks update in real-time via the SSE connection for instant visual feed
 The module includes comprehensive presets organized by category:
 
 ### Basic Category
-* **Update timeline info**: Manual refresh of show information
+
+- **Update timeline info**: Manual refresh of show information
 
 ### Timeline Control (Per Timeline)
-* **Play [Timeline Name]**: Play button with green play icon
-* **Pause [Timeline Name]**: Pause button
-* **Stop [Timeline Name]**: Stop button
-* **Toggle [Timeline Name]**: Smart play/pause toggle
+
+- **Play [Timeline Name]**: Play button with green play icon
+- **Pause [Timeline Name]**: Pause button
+- **Stop [Timeline Name]**: Stop button
+- **Toggle [Timeline Name]**: Smart play/pause toggle
 
 ### Show Management
-* **Send Input Value**: Template for sending single input values
-* **Send Multiple Inputs**: Template for sending multiple inputs via JSON
-* **Load Show from JSON**: Template for loading shows from JSON data
-* **Load Show from File**: Template for loading shows from file paths
+
+- **Send Input Value**: Template for sending single input values
+- **Send Multiple Inputs**: Template for sending multiple inputs via JSON
+- **Load Show from JSON**: Template for loading shows from JSON data
+- **Load Show from File**: Template for loading shows from file paths
 
 ### Cue Sets
-* **Set Cue Group Variant**: Template for setting single cue group variants
-* **Set Multiple Cue Groups**: Template for setting multiple cue groups via JSON
-* **Reset All Cue Groups**: Reset all cue groups to default
+
+- **Set Cue Group Variant**: Template for setting single cue group variants
+- **Set Multiple Cue Groups**: Template for setting multiple cue groups via JSON
+- **Reset All Cue Groups**: Reset all cue groups to default
 
 ### Node Management
-* **Shutdown Node**: Template for node shutdown
-* **Restart Services**: Template for service restart
+
+- **Shutdown Node**: Template for node shutdown
+- **Restart Services**: Template for service restart
 
 ### Timeline Navigation (Per Timeline with Cues)
-* **Jump to [Cue Name]**: Direct cue navigation buttons
+
+- **Jump to [Cue Name]**: Direct cue navigation buttons
 
 All presets are generated dynamically based on your show structure and update automatically when timelines or cues change.
 
 ## Advanced Features
 
 ### Input System Integration
+
 The module supports Watchout's input system for dynamic show control:
+
 - Send real-time values to show variables
 - Batch input updates for synchronized changes
 - Variable parsing support for dynamic values
 
 ### Show Loading Automation
+
 Automate show loading workflows:
+
 - Load shows from JSON data for backup/restore
 - Load shows from file paths for playlist automation
 - Automatic refresh of module state after show changes
 
 ### Enhanced Cue Set Control
+
 Advanced cue set management:
+
 - Single and batch cue group updates
 - JSON-based configuration for complex setups
 - Real-time feedback for cue set states
 
 ### Conditional Timeline Control
+
 Smart timeline automation:
+
 - Conditional playback based on timeline states
 - Cross-timeline dependencies
 - State-aware toggle operations
 
 ## Limitations
 
-* The module requires Watchout 7 with HTTP API enabled (port 3019)
-* SSE connection provides real-time updates but polling is still needed for structural changes
-* Cue information is read-only (names, times, states cannot be modified via API)
-* Node management requires direct IP access to individual nodes (port 3017)
-* Input management requires appropriate input variables to be defined in the Watchout show
+- The module requires Watchout 7 with HTTP API enabled (port 3019)
+- SSE connection provides real-time updates but polling is still needed for structural changes
+- Cue information is read-only (names, times, states cannot be modified via API)
+- Node management requires direct IP access to individual nodes (port 3017)
+- Input management requires appropriate input variables to be defined in the Watchout show
 
 ## Troubleshooting
 
-* **No timeline updates**: Check if both HTTP API (port 3019) and SSE are accessible
-* **Missing cues**: Cues only appear if they have valid names and start times in Watchout
-* **Connection issues**: Verify IP address, port accessibility, and Watchout Director is running
-* **Input errors**: Ensure input keys match exactly with show variable names
-* **Show loading failures**: Verify file paths are accessible from the Watchout Director system
+- **No timeline updates**: Check if both HTTP API (port 3019) and SSE are accessible
+- **Missing cues**: Cues only appear if they have valid names and start times in Watchout
+- **Connection issues**: Verify IP address, port accessibility, and Watchout Director is running
+- **Input errors**: Ensure input keys match exactly with show variable names
+- **Show loading failures**: Verify file paths are accessible from the Watchout Director system
 
 For detailed API documentation, refer to the [Watchout 7 External Protocol Documentation](https://docs.dataton.com/watchout-7/external_protocol/external_protocol.html).
 

--- a/main.js
+++ b/main.js
@@ -209,8 +209,8 @@ class ModuleInstance extends InstanceBase {
 							[`timeline_${countdown.timelineId}_cue_${countdown.cueId}`]: this.msToTime(countdown.delta),
 						})
 					}
-					break				
-				
+					break
+
 				case 'playbackState':
 					// update heartbeat variable
 					if (collectedData.value && collectedData.value.clockTime) {
@@ -422,6 +422,13 @@ class ModuleInstance extends InstanceBase {
 	getConfigFields() {
 		return [
 			{
+				type: 'static-text',
+				id: 'info',
+				width: 12,
+				label: 'Input Variables',
+				value: 'To use the Send Input actions, you must set the Key field in the variable properties in Watchout Producer.',
+			},
+			{
 				type: 'textinput',
 				id: 'host',
 				label: 'Director IP',
@@ -455,7 +462,7 @@ class ModuleInstance extends InstanceBase {
 	 */
 	getSortedTimelines() {
 		const timelines = []
-		
+
 		// Collect all timelines
 		if (this.show && this.show.timelines && typeof this.show.timelines === 'object') {
 			for (const key in this.show.timelines) {
@@ -467,7 +474,7 @@ class ModuleInstance extends InstanceBase {
 				}
 			}
 		}
-		
+
 		// Sort based on configuration
 		if (this.config.sortTimelines) {
 			// Sort by name when config enabled
@@ -476,7 +483,7 @@ class ModuleInstance extends InstanceBase {
 			// Default: Sort by ID to preserve Watchout's order
 			timelines.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true }))
 		}
-		
+
 		return timelines
 	}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "dataton-watchout-json",
-	"version": "2.6.0",
+	"version": "2.6.0-tony",
 	"main": "main.js",
 	"scripts": {
 		"format": "prettier -w .",


### PR DESCRIPTION
Description
This Pull Request adds functionality to specify interpolation duration when sending input values to Watchout, and clarifies important configuration requirements.

Changes:

Send Input Value: Added a Duration (ms) field to the action, allowing smooth transitions for input values.
Send Multiple Inputs: Updated default JSON and tooltips to demonstrate how to include per-item duration (e.g., [{"key": "Vol", "value": 1, "duration": 1000}]).
Documentation: Added critical warnings in 
HELP.md
, action tooltips, and module config to clarify that the Key field must be manually set in Watchout Producer for the HTTP API to work (as the API matches on Key, not Name).
Testing:

Verified single input sending with duration.
Verified multiple input sending with mixed durations in JSON.
Confirmed error handling for invalid JSON.
